### PR TITLE
Fixing: native edit text does't follow input field while long pressing

### DIFF
--- a/Android~/UnityMobileInput/mobileinput/src/main/java/ru/mopsicus/mobileinput/KeyboardListener.java
+++ b/Android~/UnityMobileInput/mobileinput/src/main/java/ru/mopsicus/mobileinput/KeyboardListener.java
@@ -13,7 +13,13 @@ import ru.mopsicus.common.Common;
 
 public class KeyboardListener implements KeyboardObserver {
 
-    private boolean isPreviousState = false;
+    private boolean previousKeyboardShowState = false;
+
+    /**
+     * Previous keyboard height to indicate if the keyboard height changed
+     */
+    private int previousKeyboardHeight = -1;
+
     private Common common = new Common();
 
     @Override
@@ -24,9 +30,13 @@ public class KeyboardListener implements KeyboardObserver {
             json.put("msg", Plugin.KEYBOARD_ACTION);
             json.put("show", isShow);
             json.put("height", height);
-        } catch (JSONException e) {}
-        if (isPreviousState != isShow) {
-            isPreviousState = isShow;
+        } catch (JSONException e) {
+
+        }
+
+        if (previousKeyboardShowState != isShow || previousKeyboardHeight != keyboardHeight) {
+            previousKeyboardShowState = isShow;
+            previousKeyboardHeight = keyboardHeight;
             common.sendData(Plugin.name, json.toString());
         }
     }

--- a/Runtime/MobileInputField.cs
+++ b/Runtime/MobileInputField.cs
@@ -309,7 +309,7 @@ namespace Mopsicus.Plugins {
                             if (!IsManualHideControl) {
                                 Hide ();
                             }
-                            return;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
For some reasons, i need to change the Unity InputField position to follow the hiding keyboard。But the MobileInputField.Update returns directly while long pressing outside the Unity InputField rect area。So i change the 'return' in MobileInput.Update to 'break' and test it fine。