### PR TITLE
Fixing: keyboard height changed event trigger

### DIFF
--- a/Android~/UnityMobileInput/mobileinput/src/main/java/ru/mopsicus/mobileinput/KeyboardListener.java
+++ b/Android~/UnityMobileInput/mobileinput/src/main/java/ru/mopsicus/mobileinput/KeyboardListener.java
@@ -13,7 +13,13 @@ import ru.mopsicus.common.Common;
 
 public class KeyboardListener implements KeyboardObserver {
 
-    private boolean isPreviousState = false;
+    private boolean previousKeyboardShowState = false;
+
+    /**
+     * Previous keyboard height to indicate if the keyboard height changed
+     */
+    private int previousKeyboardHeight = -1;
+
     private Common common = new Common();
 
     @Override
@@ -24,9 +30,13 @@ public class KeyboardListener implements KeyboardObserver {
             json.put("msg", Plugin.KEYBOARD_ACTION);
             json.put("show", isShow);
             json.put("height", height);
-        } catch (JSONException e) {}
-        if (isPreviousState != isShow) {
-            isPreviousState = isShow;
+        } catch (JSONException e) {
+
+        }
+
+        if (previousKeyboardShowState != isShow || previousKeyboardHeight != keyboardHeight) {
+            previousKeyboardShowState = isShow;
+            previousKeyboardHeight = keyboardHeight;
             common.sendData(Plugin.name, json.toString());
         }
     }

--- a/Runtime/MobileInputField.cs
+++ b/Runtime/MobileInputField.cs
@@ -213,6 +213,7 @@ namespace Mopsicus.Plugins {
         /// </summary>
         private void OnEnable () {
             if (_isMobileInputCreated) {
+                SetRectNative (this._inputObjectText.rectTransform);
                 this.SetVisible (true);
             }
         }


### PR DESCRIPTION
On some Android OS, the ViewTreeObserver trigger layout change event serveral times not just one time while the keyboard appearing, the keyboard height computed in one of the KeyboardProvider.handleOnGlobalLayout calls is not the real height of keyboard, and the KeyboardListener send the message to Unity only when the keyboard show status changed. So i just add a condition in KeyboardListener.onKeyboardHeight to make it send message to Unity when show status or height change.