### PR TITLE
Call BringToFront for (edit) in SetVisible

### DIFF
--- a/Android~/UnityMobileInput/mobileinput/src/main/java/ru/mopsicus/mobileinput/MobileInput.java
+++ b/Android~/UnityMobileInput/mobileinput/src/main/java/ru/mopsicus/mobileinput/MobileInput.java
@@ -440,8 +440,11 @@ public class MobileInput {
         if (edit == null) {
             return;
         }
-        edit.setEnabled(isVisible);
         edit.setVisibility(isVisible ? View.VISIBLE : View.INVISIBLE);
+        if(isVisible) {
+            edit.bringToFront();
+        }    
+        edit.setEnabled(isVisible);
     }
 
     // Handler to process Android buttons


### PR DESCRIPTION
Sometimes on unity's side when gameObject is disabled SetVisible(false) is called OnDisable, but when the gameObject is activated again and  SetVisible(true) is called the text remains hidden. BringToFront has to be called for the (EditText) view.