### PR TITLE
[Fix] _isFirstCreation from #94 causing duplicate field creations

### DIFF
--- a/Runtime/MobileInputField.cs
+++ b/Runtime/MobileInputField.cs
@@ -210,7 +210,7 @@ namespace UMI {
         /// <summary>
         /// Mobile input first creation flag
         /// </summary>
-        bool _isFirstCreation = true;
+        bool _initStarted = false;
 
         /// <summary>
         /// InputField object
@@ -271,8 +271,8 @@ namespace UMI {
         /// </summary>
         protected override void Start() {
             base.Start();
-            StartCoroutine(InitProcess());
-            _isFirstCreation = false;
+            if(_initStarted == false)
+                StartCoroutine(InitProcess());
         }
 
         /// <summary>
@@ -282,9 +282,9 @@ namespace UMI {
             if (_isMobileInputCreated) {
                 SetRectNative(this._inputObjectText.rectTransform);
                 SetVisible(true);
-            } else if (!_isFirstCreation) {
+            } 
+            else if (_initStarted == false)
                 StartCoroutine(InitProcess());
-            }
         }
 
         /// <summary>
@@ -363,6 +363,9 @@ namespace UMI {
         /// Initialization
         /// </summary>
         IEnumerator InitProcess() {
+            if(_initStarted == true)
+                throw new InvalidOperationException("InitProcess already started");
+            _initStarted = true;
             yield return WaitForEndOfFrame;
             PrepareNativeEdit();
 #if (UNITY_IOS || UNITY_ANDROID) && !UNITY_EDITOR


### PR DESCRIPTION
Tested and fixed on iOS.

Adding logs in Start, OnEnable and InitProcess reveals that in some cases InitProcess is called twice. Thus resulting in CreateNativeEdit also being called twice. Moving the input field position also reveals that multiple input fields where in fact created.

How I discovered / how to reproduce:
 - Create scene with input field + Some script that is able to move the input field (for me on keyboard open it moves up)
 - Open the app -> no problems
 - Swipe down from top -> disable WiFi
 - Close app (completely by swiping it away in active apps)
 - Open the app again
 - Duplicate fields pop up

This is a strange flow but the only one I can find currently to reproduce the issue and verify it's fixed.