### PR TITLE
[Fix] The app focus / pause handlers cause input fields to break

### DIFF
--- a/Runtime/MobileInputField.cs
+++ b/Runtime/MobileInputField.cs
@@ -306,26 +306,6 @@ namespace UMI {
         }
 
         /// <summary>
-        /// Handler for app focus lost
-        /// </summary>
-        void OnApplicationFocus(bool hasFocus) {
-            if (!_isMobileInputCreated || !Visible) {
-                return;
-            }
-            SetVisible(hasFocus);
-        }
-
-        /// <summary>
-        /// Handler for app focus lost
-        /// </summary>
-        void OnApplicationPause(bool hasPause) {
-            if (!_isMobileInputCreated || !Visible) {
-                return;
-            }
-            SetVisible(!hasPause);
-        }
-
-        /// <summary>
         /// Current InputField for external access
         /// </summary>
         public TMP_InputField InputField {


### PR DESCRIPTION
Tested and fixed on iOS.

How to reproduce:
- Create a scene with input field(s)
- Swipe down from above or go to the home screen to trigger a application state change
- Go back
- Input fields are not accessible anymore + content is blanked out.

Not sure what purpose they serve. I see little value in managing their accessibility on app state changes since you won't be able to access them anyway at that point. That's why I got rid of them.