### PR TITLE
[Fix] GetScreenScale has no return values on platforms other than iOS and Android

### DIFF
--- a/Runtime/MobileInput.cs
+++ b/Runtime/MobileInput.cs
@@ -427,10 +427,10 @@ namespace UMI {
         /// Check screen scale factor (iOS)
         /// </summary>
         public static float GetScreenScale() {
-#if UNITY_ANDROID
-            return 1f;
-#elif UNITY_IOS
+#if UNITY_IOS
             return scaleFactor();
+#else
+            return 1f;
 #endif
         }
 


### PR DESCRIPTION
This can be an issue for projects that also target other platforms than mobile